### PR TITLE
Now with promise support and stuff

### DIFF
--- a/extension/user.js
+++ b/extension/user.js
@@ -2,16 +2,14 @@ module.exports = function FtpExtendUser() {
 	var userName
 	return {
 		commands: {
-			USER: function(core, user) {
-				process.nextTick(function() {
-					if (user === 'anonymous') {
-						userName = user
-						core.sendControlResponse(230, [ 'Logged in as "' + userName + '".' ])
-					} else {
-						userName = undefined
-						core.sendControlResponse(530, [ 'Anonymous login requires the user name "anonymous".' ])
-					}
-				})
+			USER: function(core, user, cb) {
+				if (user === 'anonymous') {
+					userName = user
+					cb(null, '230 Logged in as "' + userName + '".')
+				} else {
+					userName = undefined
+					cb(null, '530 Anonymous login requires the user name "anonymous".')
+				}
 			}
 		},
 		core: {

--- a/ftp.js
+++ b/ftp.js
@@ -1,23 +1,27 @@
+var Promise = require('promise')
 var extendObject = require('extend')
+var denodeify = require('./improved-denodeify')
 
-module.exports = function FtpCore(controlEmitter, dataSocketEmitterCreator) {
+var stubCoreApi = {
+	getUserName: function getUserName() { return undefined },
+	isAuthenticated: function isAuthenticated() { return undefined },
+	currentDirectory: function currentDirectory() { return undefined },
+	sendControlResponse: function sendControlResponse() { throw Error('The command "sendControlResponse" is not implemented!') },
+	getDataStream: function getDataStream() { throw Error('The command "getDataStream" is not implemented!') },
+	getAllCommandNames: function getAllCommands() {
+		return []
+	}
+}
+
+module.exports = function FtpCore() {
 	var ftp = {
 		commands: {},
-		core: {
-			getUserName: function getUserName() { return undefined },
-			isAuthenticated: function isAuthenticated() { return undefined },
-			currentDirectory: function currentDirectory() { return undefined },
-			sendControlResponse: function sendControlResponse() { throw Error('The command "sendControlResponse" is not implemented!') },
-			getDataStream: function getDataStream() { throw Error('The command "getDataStream" is not implemented!') },
-			getAllCommandNames: function getAllCommands() {
-				return Object.keys(ftp.commands)
-			}
-		}
+		core: {}
 	}
 
-	ftp.extend = extend.bind(null, ftp)
-
-	return ftp
+	return extend(ftp, {
+		core: stubCoreApi
+	})
 }
 
 function extend(ftp, extension) {
@@ -26,11 +30,24 @@ function extend(ftp, extension) {
 	}
 
 	var newFtp = {
-		commands: extendObject(Object.create(ftp.commands), extension.commands || {}),
-		core: extendObject(Object.create(ftp.core), extension.core || {})
+		commands: extendObject(Object.create(ftp.commands), extension.commands),
+		core: extendObject(Object.create(ftp.core), extension.core)
 	}
 
 	newFtp.extend = extend.bind(null, newFtp)
+	newFtp.callCommand = Promise.nodeify(callCommand.bind(null, newFtp))
 
 	return newFtp
+}
+
+function callCommand(ftp, cmd, str) {
+	return new Promise(function (resolve, reject) {
+		if (!ftp.commands[cmd]) {
+			throw new Error('No such command "' + cmd + '"')
+		}
+
+		var commandFunction = denodeify(ftp.commands[cmd])
+
+		resolve(commandFunction(ftp.core, str))
+	})
 }

--- a/ftp.js
+++ b/ftp.js
@@ -29,15 +29,18 @@ function extend(ftp, extension) {
 		throw new Error('extension must be defined')
 	}
 
-	var newFtp = {
+	var internalApi = {
 		commands: extendObject(Object.create(ftp.commands), extension.commands),
 		core: extendObject(Object.create(ftp.core), extension.core)
 	}
 
-	newFtp.extend = extend.bind(null, newFtp)
-	newFtp.callCommand = Promise.nodeify(callCommand.bind(null, newFtp))
+	var publicApi = {
+		extend: extend.bind(null, internalApi),
+		callCommand: Promise.nodeify(callCommand.bind(null, internalApi)),
+		core: internalApi.core
+	}
 
-	return newFtp
+	return publicApi
 }
 
 function callCommand(ftp, cmd, str) {

--- a/improved-denodeify.js
+++ b/improved-denodeify.js
@@ -1,0 +1,24 @@
+var Promise = require('promise')
+
+// To be removed if/when https://github.com/then/promise/pull/69 hits npm
+
+module.exports = function denodeify(fn, argumentCount) {
+	argumentCount = argumentCount || Infinity
+	return function () {
+		var self = this
+		var args = Array.prototype.slice.call(arguments)
+		return new Promise(function (resolve, reject) {
+			while (args.length && args.length > argumentCount) {
+				args.pop()
+			}
+			args.push(function (err, res) {
+				if (err) reject(err)
+				else resolve(res)
+			})
+			var res = fn.apply(self, args)
+			if (res && res.then) {
+				resolve(res)
+			}
+		})
+	}
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "tape": "^3.0.3"
   },
   "dependencies": {
-    "extend": "^2.0.0"
+    "extend": "^2.0.0",
+    "promise": "^6.0.1"
   }
 }

--- a/test/extension-user-impl.js
+++ b/test/extension-user-impl.js
@@ -5,33 +5,25 @@ var FtpUser = require('../extension/user')
 test('anonymous user is authenticated', function(t) {
 	t.plan(3)
 
-	var ftp = new Ftp().extend(FtpUser()).extend({
-		core: {
-			sendControlResponse: function(number, lines) {
-				t.equals(number, 230)
-				t.ok(ftp.core.getUserName(), 'has a username')
-				t.ok(ftp.core.isAuthenticated(), 'is authenticated')
-				t.end()
-			}
-		}
-	})
+	var ftp = new Ftp().extend(FtpUser())
 
-	ftp.commands.USER(ftp.core, 'anonymous')
+	ftp.callCommand('USER', 'anonymous', function(err, response) {
+		t.equal(response.indexOf('230 '), 0, '230 response')
+		t.ok(ftp.core.getUserName(), 'has a username')
+		t.ok(ftp.core.isAuthenticated(), 'is authenticated')
+		t.end()
+	})
 })
 
 test('JohnDoe user is not authenticated', function(t) {
 	t.plan(3)
 
-	var ftp = new Ftp().extend(FtpUser()).extend({
-		core: {
-			sendControlResponse: function(number, lines) {
-				t.equals(number, 530)
-				t.notOk(ftp.core.getUserName(), 'no username')
-				t.notOk(ftp.core.isAuthenticated(), 'not authenticated')
-				t.end()
-			}
-		}
-	})
+	var ftp = new Ftp().extend(FtpUser())
 
-	ftp.commands.USER(ftp.core, 'JohnDoe')
+	ftp.callCommand('USER', 'JohnDoe').then(function(response) {
+		t.equal(response.indexOf('530 '), 0, '530 response')
+		t.notOk(ftp.core.getUserName(), 'no username')
+		t.notOk(ftp.core.isAuthenticated(), 'not authenticated')
+		t.end()
+	})
 })


### PR DESCRIPTION
- command functions can either call callbacks or return promises
- command functions are now called via ftp.callCommand(‘command’, ‘arg’) instead of ftp.commands.COMMAND(arg)
- Consumers must call callCommand - ftp.commands is no longer visible.
- command functions now return a single string instead of a number and array of strings
